### PR TITLE
Improve lunch swap workflow with cascading dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/snack-swap.yml
+++ b/.github/ISSUE_TEMPLATE/snack-swap.yml
@@ -1,5 +1,5 @@
 name: Snack Swap
-description: Request to swap your assigned lunch/snack day with another date
+description: Request to swap your assigned lunch/snack day with another family
 title: "[Snacks] Swap: "
 labels: ["snack-swap"]
 body:
@@ -18,6 +18,7 @@ body:
     id: family
     attributes:
       label: Family Name
+      description: "Your family name (the family requesting the swap)"
       placeholder: "Smith"
     validations:
       required: true
@@ -25,23 +26,31 @@ body:
     id: current_date
     attributes:
       label: Currently Assigned Date
-      description: "Format: YYYY-MM-DD"
+      description: "The date you are currently assigned to. Format: YYYY-MM-DD"
       placeholder: "2026-04-12"
     validations:
       required: true
   - type: input
-    id: preferred_date
+    id: swap_to_date
     attributes:
-      label: Preferred New Date
-      description: "Leave blank if flexible"
+      label: Swap To Date
+      description: "The date you want to swap to. Format: YYYY-MM-DD"
       placeholder: "2026-04-19"
     validations:
-      required: false
+      required: true
+  - type: input
+    id: swap_with_family
+    attributes:
+      label: Swap With Family
+      description: "The family assigned to the target date that you want to swap with"
+      placeholder: "Jones"
+    validations:
+      required: true
   - type: textarea
     id: notes
     attributes:
       label: Notes
-      description: "Any additional context (e.g. reason for swap, willing to swap with specific family)"
+      description: "Any additional context (e.g. reason for swap)"
       placeholder: "Can't make the April 12 game due to a conflict"
     validations:
       required: false

--- a/.github/workflows/process-snack-signups.yml
+++ b/.github/workflows/process-snack-signups.yml
@@ -41,11 +41,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const title = context.payload.issue.title || '';
+            const isSwap = title.includes('[Snacks] Swap');
+            const msg = isSwap
+              ? 'Snack swap approved and applied! The schedule will update on the next run.'
+              : 'Snack signup applied! It will appear on the calendar on the next scheduled run.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'Snack signup applied! It will appear on the calendar on the next scheduled run.'
+              body: msg
             });
             await github.rest.issues.update({
               owner: context.repo.owner,

--- a/process_snacks_issue.py
+++ b/process_snacks_issue.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Process a GitHub issue for snack signups.
+Process a GitHub issue for snack signups and swaps.
 
 Parses the issue body (GitHub issue form format) and updates config.json.
 Triggered by the process-snack-signups workflow when an admin comments /approve.
@@ -48,15 +48,26 @@ def save_config(config, path="config.json"):
         f.write("\n")
 
 
-def main():
-    issue_body = os.environ.get("ISSUE_BODY", "")
-    if not issue_body:
-        print("ERROR: No issue body found")
-        sys.exit(1)
+def send_ntfy(config, team, message_title, message_body):
+    """Send ntfy notification for a team."""
+    team_cfg = next((t for t in config.get("teams", []) if t["team_name"] == team), None)
+    ntfy_topic = team_cfg.get("ntfy_topic") if team_cfg else None
+    if ntfy_topic:
+        try:
+            req = urllib.request.Request(
+                f"https://ntfy.sh/{ntfy_topic}",
+                data=message_body.encode("utf-8"),
+                headers={"Title": message_title, "Priority": "default", "Tags": "baseball"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                print(f"ntfy sent to {ntfy_topic}: {message_title}")
+        except Exception as e:
+            print(f"ntfy send failed for {ntfy_topic}: {e}")
 
-    fields = parse_issue_body(issue_body)
-    print(f"Parsed fields: {json.dumps(fields, indent=2)}")
 
+def process_signup(fields, config):
+    """Process a snack signup issue."""
     team = fields.get("team", "")
     if not team:
         print("ERROR: No team specified")
@@ -77,7 +88,6 @@ def main():
         print("ERROR: No valid family names after parsing")
         sys.exit(1)
 
-    config = load_config()
     snacks = config.setdefault("snacks", {})
     team_snacks = snacks.setdefault(team, [])
 
@@ -100,24 +110,104 @@ def main():
     save_config(config)
     print("config.json updated successfully")
 
-    # Send ntfy notification to the team's topic
-    team_cfg = next((t for t in config.get("teams", []) if t["team_name"] == team), None)
-    ntfy_topic = team_cfg.get("ntfy_topic") if team_cfg else None
-    if ntfy_topic:
-        family_str = ", ".join(families)
-        title = f"Snack Signup: {date_val}"
-        body = f"{family_str} signed up for snacks on {date_val}"
-        try:
-            req = urllib.request.Request(
-                f"https://ntfy.sh/{ntfy_topic}",
-                data=body.encode("utf-8"),
-                headers={"Title": title, "Priority": "default", "Tags": "baseball"},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                print(f"ntfy sent to {ntfy_topic}: {title}")
-        except Exception as e:
-            print(f"ntfy send failed for {ntfy_topic}: {e}")
+    family_str = ", ".join(families)
+    send_ntfy(config, team, f"Snack Signup: {date_val}", f"{family_str} signed up for snacks on {date_val}")
+
+
+def process_swap(fields, config):
+    """Process a snack swap issue — performs a two-way swap."""
+    team = fields.get("team", "")
+    if not team:
+        print("ERROR: No team specified")
+        sys.exit(1)
+
+    family_name = fields.get("family_name", "").strip()
+    if not family_name:
+        print("ERROR: No family name specified")
+        sys.exit(1)
+
+    current_date = fields.get("currently_assigned_date", "").strip()
+    if not current_date:
+        print("ERROR: No currently assigned date specified")
+        sys.exit(1)
+
+    swap_to_date = fields.get("swap_to_date", "").strip()
+    if not swap_to_date:
+        print("ERROR: No swap-to date specified")
+        sys.exit(1)
+
+    swap_with_family = fields.get("swap_with_family", "").strip()
+    if not swap_with_family:
+        print("ERROR: No swap-with family specified")
+        sys.exit(1)
+
+    snacks = config.setdefault("snacks", {})
+    team_snacks = snacks.setdefault(team, [])
+
+    # Find entries for both dates
+    current_entry = None
+    target_entry = None
+    for entry in team_snacks:
+        if entry.get("date") == current_date:
+            current_entry = entry
+        if entry.get("date") == swap_to_date:
+            target_entry = entry
+
+    if not current_entry:
+        print(f"ERROR: No snack entry found for {team} on {current_date}")
+        sys.exit(1)
+
+    if not target_entry:
+        print(f"ERROR: No snack entry found for {team} on {swap_to_date}")
+        sys.exit(1)
+
+    if family_name not in current_entry.get("families", []):
+        print(f"ERROR: {family_name} is not assigned to {current_date}")
+        sys.exit(1)
+
+    if swap_with_family not in target_entry.get("families", []):
+        print(f"ERROR: {swap_with_family} is not assigned to {swap_to_date}")
+        sys.exit(1)
+
+    # Perform the swap:
+    # Remove family_name from current_date, add to swap_to_date
+    current_entry["families"].remove(family_name)
+    target_entry["families"].append(family_name)
+
+    # Remove swap_with_family from swap_to_date, add to current_date
+    target_entry["families"].remove(swap_with_family)
+    current_entry["families"].append(swap_with_family)
+
+    print(f"Swapped: {family_name} ({current_date}) <-> {swap_with_family} ({swap_to_date})")
+
+    save_config(config)
+    print("config.json updated successfully")
+
+    send_ntfy(
+        config, team,
+        f"Snack Swap: {family_name} \u2194 {swap_with_family}",
+        f"{family_name} ({current_date}) swapped with {swap_with_family} ({swap_to_date})",
+    )
+
+
+def main():
+    issue_body = os.environ.get("ISSUE_BODY", "")
+    if not issue_body:
+        print("ERROR: No issue body found")
+        sys.exit(1)
+
+    issue_title = os.environ.get("ISSUE_TITLE", "")
+
+    fields = parse_issue_body(issue_body)
+    print(f"Parsed fields: {json.dumps(fields, indent=2)}")
+
+    config = load_config()
+
+    # Determine if this is a swap or a signup based on title
+    if "[Snacks] Swap" in issue_title:
+        process_swap(fields, config)
+    else:
+        process_signup(fields, config)
 
 
 if __name__ == "__main__":

--- a/scraper.py
+++ b/scraper.py
@@ -1175,27 +1175,37 @@ def generate_index_html(all_games, config, rosters_by_team=None):
                     </div>"""
             snack_button_html = f'<button class="btn btn-snack" onclick="toggleSnackPicker(\'{picker_id}\')">Sign Up for Snacks</button>'
 
-            # Build swap picker
+            # Build swap picker with cascading dropdowns
             swap_picker_id = f"swap-picker-{slug}"
+            family_options = ""
+            for fam in family_names:
+                family_options += f'<option value="{fam}">{fam}</option>'
             swap_picker_html = f"""
                     <div class="snack-picker" id="{swap_picker_id}" style="display:none; background:#f0f4fe; border:1px solid #3b82f6; border-radius:6px; padding:10px 12px; margin-bottom:12px;">
                         <strong style="font-size:13px;">Swap Lunch Day</strong>
-                        <div style="margin:6px 0; font-size:13px;">
-                            <label style="font-size:12px; color:#555;">Your Family Name:</label><br>
-                            <input type="text" class="swap-your-family" data-picker="{swap_picker_id}" placeholder="e.g. Smith" style="padding:3px 6px; font-size:13px; width:200px; margin-top:2px;">
-                        </div>
                         <div style="margin:6px 0;">
-                            <label style="font-size:12px; color:#555;">Your Currently Assigned Date:</label>
-                            <select class="swap-current-date" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;">
-                                <option value="">Select date...</option>
-                                {date_options}
+                            <label style="font-size:12px; color:#555;">Your Family Name:</label>
+                            <select class="swap-your-family" data-picker="{swap_picker_id}" data-team="{team_name}" style="margin-left:4px; padding:2px 6px; font-size:13px;" onchange="onSwapFamilyChange(this)">
+                                <option value="">Select family...</option>
+                                {family_options}
                             </select>
                         </div>
                         <div style="margin:6px 0;">
-                            <label style="font-size:12px; color:#555;">Preferred New Date (optional):</label>
-                            <select class="swap-new-date" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;">
-                                <option value="">Any / no preference</option>
-                                {date_options}
+                            <label style="font-size:12px; color:#555;">Your Currently Assigned Date:</label>
+                            <select class="swap-current-date" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;" onchange="onSwapCurrentDateChange(this)" disabled>
+                                <option value="">Select date...</option>
+                            </select>
+                        </div>
+                        <div style="margin:6px 0;">
+                            <label style="font-size:12px; color:#555;">Swap To Date:</label>
+                            <select class="swap-new-date" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;" onchange="onSwapNewDateChange(this)" disabled>
+                                <option value="">Select date...</option>
+                            </select>
+                        </div>
+                        <div style="margin:6px 0;">
+                            <label style="font-size:12px; color:#555;">Swap With Family:</label>
+                            <select class="swap-with-family" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;" disabled>
+                                <option value="">Select family...</option>
                             </select>
                         </div>
                         <div style="margin:6px 0; font-size:13px;">
@@ -1249,6 +1259,9 @@ def generate_index_html(all_games, config, rosters_by_team=None):
                     <td style="padding:8px 6px;">{team_cfg['team_name']}</td>
                     <td style="padding:8px 6px;"><code>{topic}</code></td>
                 </tr>"""
+
+    # Build snack assignments JSON for swap picker JavaScript
+    snacks_json = json.dumps(config.get("snacks", {}))
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -1547,6 +1560,8 @@ def generate_index_html(all_games, config, rosters_by_team=None):
     </p>
 
     <script>
+        var snackAssignments = {snacks_json};
+
         function copyUrl(url) {{
             navigator.clipboard.writeText(url).then(() => {{
                 const el = document.getElementById('copied');
@@ -1663,11 +1678,119 @@ def generate_index_html(all_games, config, rosters_by_team=None):
             window.open(url, '_blank');
         }}
 
+        function onSwapFamilyChange(sel) {{
+            const picker = sel.closest('.snack-picker');
+            const teamName = sel.dataset.team;
+            const familyName = sel.value;
+            const currentDateSel = picker.querySelector('.swap-current-date');
+            const newDateSel = picker.querySelector('.swap-new-date');
+            const swapWithSel = picker.querySelector('.swap-with-family');
+
+            // Reset downstream dropdowns
+            currentDateSel.innerHTML = '<option value="">Select date...</option>';
+            currentDateSel.disabled = true;
+            newDateSel.innerHTML = '<option value="">Select date...</option>';
+            newDateSel.disabled = true;
+            swapWithSel.innerHTML = '<option value="">Select family...</option>';
+            swapWithSel.disabled = true;
+
+            if (!familyName || !teamName) return;
+
+            // Find dates this family is assigned to
+            const teamSnacks = snackAssignments[teamName] || [];
+            const assignedDates = teamSnacks.filter(function(entry) {{
+                return entry.families && entry.families.indexOf(familyName) !== -1;
+            }});
+
+            if (assignedDates.length === 0) {{
+                currentDateSel.innerHTML = '<option value="">No assigned dates found</option>';
+                return;
+            }}
+
+            currentDateSel.innerHTML = '<option value="">Select date...</option>';
+            assignedDates.forEach(function(entry) {{
+                const d = new Date(entry.date + 'T12:00:00');
+                const label = d.toLocaleDateString('en-US', {{ month: 'short', day: 'numeric' }});
+                currentDateSel.innerHTML += '<option value="' + entry.date + '">' + label + '</option>';
+            }});
+            currentDateSel.disabled = false;
+        }}
+
+        function onSwapCurrentDateChange(sel) {{
+            const picker = sel.closest('.snack-picker');
+            const familySel = picker.querySelector('.swap-your-family');
+            const teamName = familySel.dataset.team;
+            const familyName = familySel.value;
+            const currentDateVal = sel.value;
+            const newDateSel = picker.querySelector('.swap-new-date');
+            const swapWithSel = picker.querySelector('.swap-with-family');
+
+            // Reset downstream
+            newDateSel.innerHTML = '<option value="">Select date...</option>';
+            newDateSel.disabled = true;
+            swapWithSel.innerHTML = '<option value="">Select family...</option>';
+            swapWithSel.disabled = true;
+
+            if (!currentDateVal) return;
+
+            // Show all other dates that have families assigned (possible swap targets)
+            const teamSnacks = snackAssignments[teamName] || [];
+            const otherDates = teamSnacks.filter(function(entry) {{
+                return entry.date !== currentDateVal && entry.families && entry.families.length > 0;
+            }});
+
+            if (otherDates.length === 0) {{
+                newDateSel.innerHTML = '<option value="">No other dates available</option>';
+                return;
+            }}
+
+            newDateSel.innerHTML = '<option value="">Select date...</option>';
+            otherDates.forEach(function(entry) {{
+                const d = new Date(entry.date + 'T12:00:00');
+                const label = d.toLocaleDateString('en-US', {{ month: 'short', day: 'numeric' }});
+                const famList = entry.families.join(', ');
+                newDateSel.innerHTML += '<option value="' + entry.date + '">' + label + ' (' + famList + ')</option>';
+            }});
+            newDateSel.disabled = false;
+        }}
+
+        function onSwapNewDateChange(sel) {{
+            const picker = sel.closest('.snack-picker');
+            const familySel = picker.querySelector('.swap-your-family');
+            const teamName = familySel.dataset.team;
+            const familyName = familySel.value;
+            const newDateVal = sel.value;
+            const swapWithSel = picker.querySelector('.swap-with-family');
+
+            swapWithSel.innerHTML = '<option value="">Select family...</option>';
+            swapWithSel.disabled = true;
+
+            if (!newDateVal) return;
+
+            // Find families assigned to the target date
+            const teamSnacks = snackAssignments[teamName] || [];
+            const targetEntry = teamSnacks.find(function(entry) {{ return entry.date === newDateVal; }});
+            if (!targetEntry || !targetEntry.families || targetEntry.families.length === 0) return;
+
+            // Exclude the requesting family (in case they appear on that date too)
+            const candidates = targetEntry.families.filter(function(f) {{ return f !== familyName; }});
+            if (candidates.length === 0) {{
+                swapWithSel.innerHTML = '<option value="">No families to swap with</option>';
+                return;
+            }}
+
+            swapWithSel.innerHTML = '<option value="">Select family...</option>';
+            candidates.forEach(function(f) {{
+                swapWithSel.innerHTML += '<option value="' + f + '">' + f + '</option>';
+            }});
+            swapWithSel.disabled = false;
+        }}
+
         function submitSwapRequest(pickerId, teamName) {{
             const picker = document.getElementById(pickerId);
-            const familyInput = picker.querySelector('.swap-your-family');
-            const familyName = familyInput ? familyInput.value.trim() : '';
-            if (!familyName) {{ alert('Please enter your family name.'); return; }}
+            const familySel = picker.querySelector('.swap-your-family');
+            const familyName = familySel ? familySel.value : '';
+            if (!familyName) {{ alert('Please select your family name.'); return; }}
 
             const currentDate = picker.querySelector('.swap-current-date');
             const currentDateVal = currentDate ? currentDate.value : '';
@@ -1675,17 +1798,22 @@ def generate_index_html(all_games, config, rosters_by_team=None):
 
             const newDate = picker.querySelector('.swap-new-date');
             const newDateVal = newDate ? newDate.value : '';
-            const newDateStr = newDateVal || 'Any / no preference';
+            if (!newDateVal) {{ alert('Please select the date to swap to.'); return; }}
+
+            const swapWith = picker.querySelector('.swap-with-family');
+            const swapWithVal = swapWith ? swapWith.value : '';
+            if (!swapWithVal) {{ alert('Please select the family to swap with.'); return; }}
 
             const notesInput = picker.querySelector('.swap-notes');
             const notes = notesInput ? notesInput.value.trim() : '';
 
-            const title = encodeURIComponent('[Snacks] Swap: ' + familyName + ' - ' + currentDateVal);
+            const title = encodeURIComponent('[Snacks] Swap: ' + familyName + ' (' + currentDateVal + ') \u2194 ' + swapWithVal + ' (' + newDateVal + ')');
             const body = encodeURIComponent(
                 '### Team\\n\\n' + teamName +
                 '\\n\\n### Family Name\\n\\n' + familyName +
                 '\\n\\n### Currently Assigned Date\\n\\n' + currentDateVal +
-                '\\n\\n### Preferred New Date\\n\\n' + newDateStr +
+                '\\n\\n### Swap To Date\\n\\n' + newDateVal +
+                '\\n\\n### Swap With Family\\n\\n' + swapWithVal +
                 (notes ? '\\n\\n### Notes\\n\\n' + notes : '')
             );
             const url = 'https://github.com/aknowles/milton-club-baseball/issues/new?labels=snack-swap&title=' + title + '&body=' + body;


### PR DESCRIPTION
- Family name is now a dropdown populated from the team roster
- Selecting a family auto-populates only their assigned dates
- Selecting a swap-to date shows which families are on that day
- User picks the specific family to swap with
- Approval workflow performs a true two-way swap in config.json
- Updated issue template with swap-with-family field

https://claude.ai/code/session_01UzmAiYFvSoZht8aD8jqpJZ