### PR TITLE
Support one-way lunch transfers in addition to two-way swaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/snack-swap.yml
+++ b/.github/ISSUE_TEMPLATE/snack-swap.yml
@@ -1,5 +1,5 @@
 name: Snack Swap
-description: Request to swap your assigned lunch/snack day with another family
+description: Request to swap your assigned lunch/snack day with another family, or transfer to a different date
 title: "[Snacks] Swap: "
 labels: ["snack-swap"]
 body:
@@ -42,10 +42,10 @@ body:
     id: swap_with_family
     attributes:
       label: Swap With Family
-      description: "The family assigned to the target date that you want to swap with"
-      placeholder: "Jones"
+      description: "The family assigned to the target date that you want to swap with. Leave blank for a one-way transfer (you move dates, no return swap)."
+      placeholder: "Jones (or leave blank for one-way transfer)"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: notes
     attributes:

--- a/process_snacks_issue.py
+++ b/process_snacks_issue.py
@@ -115,7 +115,7 @@ def process_signup(fields, config):
 
 
 def process_swap(fields, config):
-    """Process a snack swap issue — performs a two-way swap."""
+    """Process a snack swap issue — two-way swap or one-way transfer."""
     team = fields.get("team", "")
     if not team:
         print("ERROR: No team specified")
@@ -137,9 +137,8 @@ def process_swap(fields, config):
         sys.exit(1)
 
     swap_with_family = fields.get("swap_with_family", "").strip()
-    if not swap_with_family:
-        print("ERROR: No swap-with family specified")
-        sys.exit(1)
+    if swap_with_family == "_No response_":
+        swap_with_family = ""
 
     snacks = config.setdefault("snacks", {})
     team_snacks = snacks.setdefault(team, [])
@@ -157,37 +156,49 @@ def process_swap(fields, config):
         print(f"ERROR: No snack entry found for {team} on {current_date}")
         sys.exit(1)
 
-    if not target_entry:
-        print(f"ERROR: No snack entry found for {team} on {swap_to_date}")
-        sys.exit(1)
-
     if family_name not in current_entry.get("families", []):
         print(f"ERROR: {family_name} is not assigned to {current_date}")
         sys.exit(1)
 
-    if swap_with_family not in target_entry.get("families", []):
-        print(f"ERROR: {swap_with_family} is not assigned to {swap_to_date}")
-        sys.exit(1)
+    # Create target entry if it doesn't exist (for one-way transfers to unassigned dates)
+    if not target_entry:
+        target_entry = {"date": swap_to_date, "families": []}
+        team_snacks.append(target_entry)
 
-    # Perform the swap:
-    # Remove family_name from current_date, add to swap_to_date
-    current_entry["families"].remove(family_name)
-    target_entry["families"].append(family_name)
+    if swap_with_family:
+        # Two-way swap
+        if swap_with_family not in target_entry.get("families", []):
+            print(f"ERROR: {swap_with_family} is not assigned to {swap_to_date}")
+            sys.exit(1)
 
-    # Remove swap_with_family from swap_to_date, add to current_date
-    target_entry["families"].remove(swap_with_family)
-    current_entry["families"].append(swap_with_family)
+        current_entry["families"].remove(family_name)
+        target_entry["families"].append(family_name)
+        target_entry["families"].remove(swap_with_family)
+        current_entry["families"].append(swap_with_family)
 
-    print(f"Swapped: {family_name} ({current_date}) <-> {swap_with_family} ({swap_to_date})")
+        print(f"Swapped: {family_name} ({current_date}) <-> {swap_with_family} ({swap_to_date})")
+        save_config(config)
+        print("config.json updated successfully")
 
-    save_config(config)
-    print("config.json updated successfully")
+        send_ntfy(
+            config, team,
+            f"Snack Swap: {family_name} \u2194 {swap_with_family}",
+            f"{family_name} ({current_date}) swapped with {swap_with_family} ({swap_to_date})",
+        )
+    else:
+        # One-way transfer — just move the family to the new date
+        current_entry["families"].remove(family_name)
+        target_entry["families"].append(family_name)
 
-    send_ntfy(
-        config, team,
-        f"Snack Swap: {family_name} \u2194 {swap_with_family}",
-        f"{family_name} ({current_date}) swapped with {swap_with_family} ({swap_to_date})",
-    )
+        print(f"Transferred: {family_name} from {current_date} -> {swap_to_date}")
+        save_config(config)
+        print("config.json updated successfully")
+
+        send_ntfy(
+            config, team,
+            f"Snack Transfer: {family_name}",
+            f"{family_name} moved from {current_date} to {swap_to_date}",
+        )
 
 
 def main():

--- a/scraper.py
+++ b/scraper.py
@@ -1323,6 +1323,7 @@ def generate_index_html(all_games, config, rosters_by_team=None):
                             <select class="swap-with-family" data-picker="{swap_picker_id}" style="margin-left:4px; padding:2px 6px; font-size:13px;" disabled>
                                 <option value="">Select family...</option>
                             </select>
+                            <div style="font-size:11px; color:#888; margin-top:2px;">Leave as &ldquo;None&rdquo; for a one-way transfer (no return swap)</div>
                         </div>
                         <div style="margin:6px 0; font-size:13px;">
                             <label style="font-size:12px; color:#555;">Notes (optional):</label><br>
@@ -1862,10 +1863,10 @@ def generate_index_html(all_games, config, rosters_by_team=None):
 
             if (!currentDateVal) return;
 
-            // Show all other dates that have families assigned (possible swap targets)
+            // Show all other snack dates as possible swap/transfer targets
             const teamSnacks = snackAssignments[teamName] || [];
             const otherDates = teamSnacks.filter(function(entry) {{
-                return entry.date !== currentDateVal && entry.families && entry.families.length > 0;
+                return entry.date !== currentDateVal;
             }});
 
             if (otherDates.length === 0) {{
@@ -1877,7 +1878,7 @@ def generate_index_html(all_games, config, rosters_by_team=None):
             otherDates.forEach(function(entry) {{
                 const d = new Date(entry.date + 'T12:00:00');
                 const label = d.toLocaleDateString('en-US', {{ month: 'short', day: 'numeric' }});
-                const famList = entry.families.join(', ');
+                const famList = entry.families && entry.families.length > 0 ? entry.families.join(', ') : 'no families';
                 newDateSel.innerHTML += '<option value="' + entry.date + '">' + label + ' (' + famList + ')</option>';
             }});
             newDateSel.disabled = false;
@@ -1896,22 +1897,19 @@ def generate_index_html(all_games, config, rosters_by_team=None):
 
             if (!newDateVal) return;
 
+            // Always offer "None" for one-way transfer
+            swapWithSel.innerHTML = '<option value="">None (one-way transfer)</option>';
+
             // Find families assigned to the target date
             const teamSnacks = snackAssignments[teamName] || [];
             const targetEntry = teamSnacks.find(function(entry) {{ return entry.date === newDateVal; }});
-            if (!targetEntry || !targetEntry.families || targetEntry.families.length === 0) return;
-
-            // Exclude the requesting family (in case they appear on that date too)
-            const candidates = targetEntry.families.filter(function(f) {{ return f !== familyName; }});
-            if (candidates.length === 0) {{
-                swapWithSel.innerHTML = '<option value="">No families to swap with</option>';
-                return;
+            if (targetEntry && targetEntry.families && targetEntry.families.length > 0) {{
+                // Exclude the requesting family (in case they appear on that date too)
+                const candidates = targetEntry.families.filter(function(f) {{ return f !== familyName; }});
+                candidates.forEach(function(f) {{
+                    swapWithSel.innerHTML += '<option value="' + f + '">' + f + '</option>';
+                }});
             }}
-
-            swapWithSel.innerHTML = '<option value="">Select family...</option>';
-            candidates.forEach(function(f) {{
-                swapWithSel.innerHTML += '<option value="' + f + '">' + f + '</option>';
-            }});
             swapWithSel.disabled = false;
         }}
 
@@ -1931,20 +1929,32 @@ def generate_index_html(all_games, config, rosters_by_team=None):
 
             const swapWith = picker.querySelector('.swap-with-family');
             const swapWithVal = swapWith ? swapWith.value : '';
-            if (!swapWithVal) {{ alert('Please select the family to swap with.'); return; }}
 
             const notesInput = picker.querySelector('.swap-notes');
             const notes = notesInput ? notesInput.value.trim() : '';
 
-            const title = encodeURIComponent('[Snacks] Swap: ' + familyName + ' (' + currentDateVal + ') \u2194 ' + swapWithVal + ' (' + newDateVal + ')');
-            const body = encodeURIComponent(
-                '### Team\\n\\n' + teamName +
-                '\\n\\n### Family Name\\n\\n' + familyName +
-                '\\n\\n### Currently Assigned Date\\n\\n' + currentDateVal +
-                '\\n\\n### Swap To Date\\n\\n' + newDateVal +
-                '\\n\\n### Swap With Family\\n\\n' + swapWithVal +
-                (notes ? '\\n\\n### Notes\\n\\n' + notes : '')
-            );
+            var title, body;
+            if (swapWithVal) {{
+                title = encodeURIComponent('[Snacks] Swap: ' + familyName + ' (' + currentDateVal + ') \u2194 ' + swapWithVal + ' (' + newDateVal + ')');
+                body = encodeURIComponent(
+                    '### Team\\n\\n' + teamName +
+                    '\\n\\n### Family Name\\n\\n' + familyName +
+                    '\\n\\n### Currently Assigned Date\\n\\n' + currentDateVal +
+                    '\\n\\n### Swap To Date\\n\\n' + newDateVal +
+                    '\\n\\n### Swap With Family\\n\\n' + swapWithVal +
+                    (notes ? '\\n\\n### Notes\\n\\n' + notes : '')
+                );
+            }} else {{
+                title = encodeURIComponent('[Snacks] Swap: ' + familyName + ' (' + currentDateVal + ') \u2192 ' + newDateVal);
+                body = encodeURIComponent(
+                    '### Team\\n\\n' + teamName +
+                    '\\n\\n### Family Name\\n\\n' + familyName +
+                    '\\n\\n### Currently Assigned Date\\n\\n' + currentDateVal +
+                    '\\n\\n### Swap To Date\\n\\n' + newDateVal +
+                    '\\n\\n### Swap With Family\\n\\n' +
+                    (notes ? '\\n\\n### Notes\\n\\n' + notes : '')
+                );
+            }}
             const url = 'https://github.com/aknowles/milton-club-baseball/issues/new?labels=snack-swap&title=' + title + '&body=' + body;
             window.open(url, '_blank');
         }}


### PR DESCRIPTION
The "Swap With Family" field is now optional across the form, issue
template, and processing logic. When left blank, the requesting family
is simply moved to the new date (one-way transfer) without requiring a
return swap. No debt tracking — the calendar naturally shows which dates
are short-handed.

https://claude.ai/code/session_012Bv3gscfSDZTnqgDu6F62R