### PR TITLE
Add MDB Knights 13U Gold, 13U Blue, and 10U Gold teams

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-practice.yml
+++ b/.github/ISSUE_TEMPLATE/add-practice.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/cancel-practice.yml
+++ b/.github/ISSUE_TEMPLATE/cancel-practice.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/game-status.yml
+++ b/.github/ISSUE_TEMPLATE/game-status.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/modify-practice.yml
+++ b/.github/ISSUE_TEMPLATE/modify-practice.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/snack-signup.yml
+++ b/.github/ISSUE_TEMPLATE/snack-signup.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/snack-swap.yml
+++ b/.github/ISSUE_TEMPLATE/snack-swap.yml
@@ -11,6 +11,9 @@ body:
         - MDB Knights 11U Gold
         - MDB Knights 14U Blue
         - MDB Knights 11U Blue
+        - MDB Knights 13U Gold
+        - MDB Knights 13U Blue
+        - MDB Knights 10U Gold
         - Braintree Bandits 11U Mercado
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ To receive notifications:
 | MDB Knights 11U Gold | 11U | `mdb-knights-11u-gold` |
 | MDB Knights 14U Blue | 14U | `mdb-knights-14u-blue` |
 | MDB Knights 11U Blue | 11U | `mdb-knights-11u-blue` |
+| MDB Knights 13U Gold | 13U | `mdb-knights-13u-gold` |
+| MDB Knights 13U Blue | 13U | `mdb-knights-13u-blue` |
+| MDB Knights 10U Gold | 10U | `mdb-knights-10u-gold` |
 | Braintree Bandits 11U Mercado | 11U | `braintree-bandits-11u-mercado` |
 
 Teams are configured in `config.json`. To add a team, add an entry with the Perfect Game team page URL, team name, year, and ntfy topic.

--- a/config.json
+++ b/config.json
@@ -28,6 +28,27 @@
       "snack_signup": false
     },
     {
+      "url": "https://www.perfectgame.org/PGBA/Team/default.aspx?orgid=26795&orgteamid=270157&Year=2026",
+      "team_name": "MDB Knights 13U Gold",
+      "year": 2026,
+      "ntfy_topic": "mdb-knights-13u-gold",
+      "snack_signup": false
+    },
+    {
+      "url": "https://www.perfectgame.org/PGBA/Team/default.aspx?orgid=26795&orgteamid=270158&Year=2026",
+      "team_name": "MDB Knights 13U Blue",
+      "year": 2026,
+      "ntfy_topic": "mdb-knights-13u-blue",
+      "snack_signup": false
+    },
+    {
+      "url": "https://www.perfectgame.org/PGBA/Team/default.aspx?orgid=26795&orgteamid=270149&Year=2026",
+      "team_name": "MDB Knights 10U Gold",
+      "year": 2026,
+      "ntfy_topic": "mdb-knights-10u-gold",
+      "snack_signup": false
+    },
+    {
       "url": "https://www.perfectgame.org/PGBA/Team/default.aspx?orgid=76990&orgteamid=272240&team=1050136&Year=2026",
       "team_name": "Braintree Bandits 11U Mercado",
       "year": 2026,
@@ -58,6 +79,21 @@
       "blackout_dates": []
     },
     "MDB Knights 11U Blue": {
+      "adhoc": [],
+      "modifications": [],
+      "blackout_dates": []
+    },
+    "MDB Knights 13U Gold": {
+      "adhoc": [],
+      "modifications": [],
+      "blackout_dates": []
+    },
+    "MDB Knights 13U Blue": {
+      "adhoc": [],
+      "modifications": [],
+      "blackout_dates": []
+    },
+    "MDB Knights 10U Gold": {
       "adhoc": [],
       "modifications": [],
       "blackout_dates": []
@@ -164,6 +200,9 @@
     ],
     "MDB Knights 14U Blue": [],
     "MDB Knights 11U Blue": [],
+    "MDB Knights 13U Gold": [],
+    "MDB Knights 13U Blue": [],
+    "MDB Knights 10U Gold": [],
     "Braintree Bandits 11U Mercado": []
   }
 }


### PR DESCRIPTION
Register the three new teams in config.json (schedule URL, ntfy topic,
empty practices/snacks sections) and expose them in the issue template
team dropdowns and README roster.