### PR TITLE
Bump upload-pages-artifact and deploy-pages to Node.js 24 versions

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -57,7 +57,7 @@ jobs:
         run: python scraper.py
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: .
 
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   notify-failure:
     needs: [scrape, deploy]


### PR DESCRIPTION
upload-pages-artifact@v3 bundled upload-artifact@v4 (Node.js 20) and deploy-pages@v4 itself runs on Node.js 20. v5 of each runs on Node.js 24.