### PR TITLE
Preserve <br>-separated whitespace when reading schedule rows

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -422,7 +422,12 @@ def parse_schedule(html, team_name, team_url):
         if not cells:
             continue
 
-        cell_texts = [c.get_text(strip=True) for c in cells]
+        # Use " " as the separator so PG's frequent <br> tags become real
+        # whitespace in the extracted text. Without this, BeautifulSoup
+        # squashes "W, 10-16<br>vs. Opponent" down to "W,10-16vs.Opponent",
+        # which breaks the trailing word boundary on the score regex and
+        # also fuses date parts ("Apr<br>11<br>Sat" → "Apr11Sat").
+        cell_texts = [c.get_text(" ", strip=True) for c in cells]
         full_text = " ".join(cell_texts)
         if not full_text.strip():
             continue
@@ -509,9 +514,12 @@ def parse_game_row(cells, cell_texts, full_text, game_link,
         is_allday = True
 
     # --- Home/Away ---
+    # Match a standalone "@" (as a word — preceded and followed by non-word
+    # characters). \b@\b doesn't work because \b requires a word/non-word
+    # boundary, and "@" is non-word on both sides of any surrounding space.
     if re.search(r"\bvs\.?\b", full_text, re.I):
         home_away = "vs."
-    elif re.search(r"\b@\b", full_text):
+    elif re.search(r"(?<!\w)@(?!\w)", full_text):
         home_away = "@"
     else:
         home_away = "vs."


### PR DESCRIPTION
Perfect Game wraps the score, "vs./@" marker, opponent, and record in separate <br>-delimited lines inside the same table cell. BeautifulSoup's get_text(strip=True) (no separator) concatenates those text nodes with no whitespace, so "W, 10-16<br>vs. Opponent" came through as "W,10-16vs.Opponent". The score regex then failed its trailing \b (digit-to-letter has no word boundary), and the primary date regex also silently fell through to its weaker fallback on "Apr<br>11<br>Sat".

Pass " " as the separator so the extracted text matches what a human sees, then fix one collateral regression: \b@\b only matched when "@" had word characters on *both* sides, which happened accidentally when the text was squashed (e.g. "17-1@Boomer"). Now that spaces are preserved, "17-1 @ Boomer" no longer has word chars adjacent to "@", so "@" detection flipped away games back to "vs.". Replace with (?<!\w)@(?!\w) which correctly matches a standalone "@" regardless of whitespace — still excludes "@" embedded in emails or similar word contexts.

Verified end-to-end against the four real 11U Gold completed rows: they now parse as W 16-10, W 17-1, W 15-9, and W 16-6.

https://claude.ai/code/session_01ARFjLALJpFR6YBSnqaXDQo