### PR TITLE
Run scraper four times daily during the active season

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -2,9 +2,13 @@ name: Update Baseball Calendar
 
 on:
   schedule:
-    # Once daily at 8 AM ET (UTC-4), March through July only — the active
-    # season. Outside those months, use workflow_dispatch to run manually.
-    - cron: '0 12 * 3-7 *'
+    # Four times daily at 6 AM, 11 AM, 4 PM, and 10 PM ET (UTC-4), March
+    # through July only — the active season. Outside those months, use
+    # workflow_dispatch to run manually.
+    - cron: '0 10 * 3-7 *'
+    - cron: '0 15 * 3-7 *'
+    - cron: '0 20 * 3-7 *'
+    - cron: '0 2 * 3-7 *'
   workflow_dispatch:
   push:
     branches: [main]

--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -2,13 +2,18 @@ name: Update Baseball Calendar
 
 on:
   schedule:
-    # Four times daily at 6 AM, 11 AM, 4 PM, and 10 PM ET (UTC-4), March
-    # through July only — the active season. Outside those months, use
-    # workflow_dispatch to run manually.
-    - cron: '0 10 * 3-7 *'
-    - cron: '0 15 * 3-7 *'
-    - cron: '0 20 * 3-7 *'
-    - cron: '0 2 * 3-7 *'
+    # Active season (March–June): four times daily at 6 AM, 11 AM, 4 PM,
+    # and 10 PM ET (UTC-4).
+    - cron: '0 10 * 3-6 *'
+    - cron: '0 15 * 3-6 *'
+    - cron: '0 20 * 3-6 *'
+    - cron: '0 2 * 3-6 *'
+    # Late summer (July–August): once daily at 8 AM ET.
+    - cron: '0 12 * 7-8 *'
+    # Off-season (September–February): three times weekly,
+    # Mon/Wed/Fri at 8 AM ET.
+    - cron: '0 12 * 9-12 1,3,5'
+    - cron: '0 12 * 1-2 1,3,5'
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
Bump the cron schedule from once daily (8 AM ET) to four runs spread
across the day at 6 AM, 11 AM, 4 PM, and 10 PM ET. Keeps the existing
March–July seasonal restriction; outside those months operators still
trigger runs manually.